### PR TITLE
Fix: 다축 FFT 특징을 하나의 입력 샘플로 통합

### DIFF
--- a/AT_AFO_project/models/model_training.py
+++ b/AT_AFO_project/models/model_training.py
@@ -8,10 +8,11 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import mean_squared_error
 from fft_analysis import fft_analysis
 
-# ML 모델 학습 + 예측 함수
+# ML 모델 학습 및 예측 함수
 def train_and_predict(data_dir='data', sample_rate=4096):
     csv_files = glob.glob(os.path.join(data_dir, '*.csv'))
     X, y = [], []
+    axes = ['Accel_X', 'Accel_Y', 'Accel_Z', 'Gyro_X', 'Gyro_Y', 'Gyro_Z']
 
     for file in csv_files:
         df = pd.read_csv(file)
@@ -19,20 +20,23 @@ def train_and_predict(data_dir='data', sample_rate=4096):
         if 'Resonant_Frequency' not in df.columns or pd.isnull(df['Resonant_Frequency'].iloc[0]):
             continue
 
-        axes = ['Accel_X', 'Accel_Y', 'Accel_Z', 'Gyro_X', 'Gyro_Y', 'Gyro_Z']
-
-        # 각 축에 대해 FFT 특징 추출
+        features = []
         for axis in axes:
             if axis not in df.columns:
+                features.extend([0, 0])  # 없는 축 -> 0으로
                 continue
+
             data = df[axis].dropna().to_numpy()
             if len(data) == 0:
+                features.extend([0, 0])  # 데이터가 없을 경우 -> 0으로
                 continue
-            x_fft, y_fft = fft_analysis(data, sample_rate)
-            peak_frequency = x_fft[np.argmax(y_fft)]
-            peak_amplitude = np.max(y_fft)
-            X.append([peak_frequency, peak_amplitude])
-            y.append(df['Resonant_Frequency'].iloc[0])
+
+            _, y_fft, peak_freq = fft_analysis(data, sample_rate, plot=False)
+            peak_amp = np.max(y_fft)
+            features.extend([peak_freq, peak_amp])
+
+        X.append(features)
+        y.append(df['Resonant_Frequency'].iloc[0])
 
     X = np.array(X)
     y = np.array(y)
@@ -44,9 +48,10 @@ def train_and_predict(data_dir='data', sample_rate=4096):
 
         y_pred = model.predict(X_test)
         mse = mean_squared_error(y_test, y_pred)
-        print(f'\n Mean Squared Error: {mse:.3f}')
+        print(f'\nMean Squared Error: {mse:.3f}')
 
-        plt.scatter(y_test, y_pred)
+        plt.figure(figsize=(8, 6))
+        plt.scatter(y_test, y_pred, alpha=0.7)
         plt.plot([y.min(), y.max()], [y.min(), y.max()], 'r--')
         plt.xlabel('True Resonant Frequency')
         plt.ylabel('Predicted Resonant Frequency')
@@ -54,4 +59,4 @@ def train_and_predict(data_dir='data', sample_rate=4096):
         plt.grid(True)
         plt.show()
     else:
-        print("데이터 부족")
+        print("데이터가 충분하지 않습니다.")


### PR DESCRIPTION
[Fix] 각 센서 축의 FFT 특징(공진 주파수 및 진폭)을 단일 벡터로 통합, fft_analysis() 함수의 plot=False 옵션을 반영하여 훈련 속도 향상